### PR TITLE
Support optional -fs flag in ffuf subdomain helper

### DIFF
--- a/ffuf-subdomains.sh
+++ b/ffuf-subdomains.sh
@@ -2,10 +2,11 @@
 
 # This script runs ffuf with a wordlist, URL, and Host header provided as arguments.
 
-# Check if all three arguments are provided
-if [ "$#" -ne 3 ]; then
-    echo "Usage: $0 <wordlist_file> <target_url> <target_host>"
+# Check if the required arguments (and optional -fs) are provided
+if [ "$#" -ne 3 ] && [ "$#" -ne 5 ]; then
+    echo "Usage: $0 <wordlist_file> <target_url> <target_host> [-fs <size>]"
     echo "Example: $0 wordlist.txt http://10.10.10.10 example.com"
+    echo "Example: $0 wordlist.txt http://10.10.10.10 example.com -fs 4242"
     exit 1
 fi
 
@@ -13,13 +14,26 @@ fi
 WORDLIST=$1
 URL=$2
 HOST=$3
+FILTER_SIZE=""
+
+# Parse optional -fs flag when provided
+if [ "$#" -eq 5 ]; then
+    if [ "$4" != "-fs" ] || [ -z "$5" ]; then
+        echo "Error: Optional flag must be provided as -fs <size>."
+        echo "Usage: $0 <wordlist_file> <target_url> <target_host> [-fs <size>]"
+        exit 1
+    fi
+    FILTER_SIZE=$5
+fi
 
 # Run ffuf once without filtering to let the user observe the response size
 echo "🚀 Running initial command (without -fs): ffuf -w $WORDLIST -u $URL -H \"Host: FUZZ.$HOST\""
 ffuf -w "$WORDLIST" -u "$URL" -H "Host: FUZZ.$HOST"
 
-# Prompt the user for the response size to filter out
-read -p $'Enter the response size to filter with -fs (press Enter to skip): ' FILTER_SIZE
+# Prompt the user for the response size to filter out if not supplied via -fs
+if [[ -z "$FILTER_SIZE" ]]; then
+    read -p $'Enter the response size to filter with -fs (press Enter to skip): ' FILTER_SIZE
+fi
 
 if [[ -n "$FILTER_SIZE" ]]; then
     echo "🚀 Running command with -fs $FILTER_SIZE: ffuf -w $WORDLIST -u $URL -H \"Host: FUZZ.$HOST\" -fs $FILTER_SIZE"


### PR DESCRIPTION
## Summary
- accept an optional `-fs <size>` pair in `ffuf-subdomains.sh`
- parse the optional filter size and reuse it for the rerun
- refresh the usage text to cover the new invocation form

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d77bfcd8008332a0a1f696454c056e